### PR TITLE
Make document type optional

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ function bulkWriteStream (options = {}) {
   writeStream._write = function (chunk, encoding, callback) {
     const body = chunk.reduce((prev, curr) => {
       if (['index', 'update', 'delete'].indexOf(curr.action) < 0) { return prev }
-      if (!curr.index || !curr.type || !curr.id || !curr.doc) { return prev }
+      if (!curr.index || !curr.id || !curr.doc) { return prev }
       if (curr.action === 'index') { prev.push({ index: { _index: curr.index, _type: curr.type, _id: curr.id } }, curr.doc) }
       if (curr.action === 'update') { prev.push({ update: { _index: curr.index, _type: curr.type, _id: curr.id } }, { doc: curr.doc }) }
       if (curr.action === 'delete') { prev.push({ delete: { _index: curr.index, _type: curr.type, _id: curr.id } }) }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -76,9 +76,21 @@ test('ignore missing arguments', t => {
   })
   const writeStream = ebs.bulkWriteStream({ client })
   writeStream.write({ index: null, type: 'mytype', id: '12345', action: 'index', doc: { name: 'test' } })
-  writeStream.write({ index: 'myindex', type: null, id: '12345', action: 'index', doc: { name: 'test' } })
   writeStream.write({ index: 'myindex', type: 'mytype', id: null, action: 'index', doc: { name: 'test' } })
   writeStream.write({ index: 'myindex', type: 'mytype', id: '12345', action: 'index', doc: null })
+  writeStream.end()
+})
+
+test('type is optional', t => {
+  t.plan(1)
+
+  const client = getClient()
+  sinon.stub(client, 'bulk').callsFake((data, callback) => {
+    t.equal(data.body.length, 4)
+  })
+  const writeStream = ebs.bulkWriteStream({ client })
+  writeStream.write({ index: 'myindex', type: 'mytype', id: '12345', action: 'index', doc: { name: 'test' } })
+  writeStream.write({ index: 'myindex', type: null, id: '12345', action: 'index', doc: { name: 'test' } })
   writeStream.end()
 })
 


### PR DESCRIPTION
Mapping types have been abolished in Elasticsearch 7.0.0:
https://www.elastic.co/guide/en/elasticsearch/reference/master/removal-of-types.html